### PR TITLE
Added line splitting support to typewriter

### DIFF
--- a/Source/StevesUEHelpers/Private/StevesUI/TypewriterTextWidget.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/TypewriterTextWidget.cpp
@@ -70,12 +70,18 @@ FText UTypewriterTextWidget::GetText() const
 
 void UTypewriterTextWidget::PlayLine(const FText& InLine, float Speed)
 {
+	CurrentLine = InLine;
+	RemainingLinePart = CurrentLine.ToString();
+	PlayNextLinePart(Speed);
+}
+
+void UTypewriterTextWidget::PlayNextLinePart(float Speed)
+{
 	check(GetWorld());
 
 	FTimerManager& TimerManager = GetWorld()->GetTimerManager();
 	TimerManager.ClearTimer(LetterTimer);
 
-	CurrentLine = InLine;
 	CurrentRunName = "";
 	CurrentLetterIndex = 0;
 	CachedLetterIndex = 0;
@@ -87,7 +93,7 @@ void UTypewriterTextWidget::PlayLine(const FText& InLine, float Speed)
 	Segments.Empty();
 	CachedSegmentText.Empty();
 
-	if (CurrentLine.IsEmpty())
+	if (RemainingLinePart.IsEmpty())
 	{
 		if (IsValid(LineText))
 		{
@@ -107,6 +113,7 @@ void UTypewriterTextWidget::PlayLine(const FText& InLine, float Speed)
 			LineText->SetText(FText::GetEmpty());
 		}
 
+		bHasMoreLineParts = false;
 		bHasFinishedPlaying = false;
 
 		if (bFirstPlayLine)
@@ -127,7 +134,20 @@ void UTypewriterTextWidget::PlayLine(const FText& InLine, float Speed)
 
 void UTypewriterTextWidget::StartPlayLine()
 {
-	CalculateWrappedString();
+	CalculateWrappedString(RemainingLinePart);
+
+	if (NumberOfLines > MaxNumberOfLines)
+	{
+		int MaxLength = CalculateMaxLength();
+		int TerminatorIndex = FindLastTerminator(RemainingLinePart, MaxLength);
+		int Length = TerminatorIndex + 1;
+		const FString& FirstLinePart = RemainingLinePart.Left(Length);
+
+		CalculateWrappedString(FirstLinePart);
+
+		RemainingLinePart.RightChopInline(Length);
+		bHasMoreLineParts = true;
+	}
 		
 	FTimerDelegate Delegate;
 	Delegate.BindUObject(this, &ThisClass::PlayNextLetter);
@@ -214,7 +234,59 @@ bool UTypewriterTextWidget::IsSentenceTerminator(TCHAR Letter)
 	return Letter == '.' || Letter == '!' || Letter == '?';
 }
 
-void UTypewriterTextWidget::CalculateWrappedString()
+bool UTypewriterTextWidget::IsClauseTerminator(TCHAR Letter)
+{
+	return Letter == ',' || Letter == ';';
+}
+
+int UTypewriterTextWidget::FindLastTerminator(const FString& CurrentLineString, int Count)
+{
+	int TerminatorIndex = CurrentLineString.FindLastCharByPredicate(IsSentenceTerminator, Count);
+	if (TerminatorIndex != INDEX_NONE)
+	{
+		return TerminatorIndex;
+	}
+
+	TerminatorIndex = CurrentLineString.FindLastCharByPredicate(IsClauseTerminator, Count);
+	if (TerminatorIndex != INDEX_NONE)
+	{
+		return TerminatorIndex;
+	}
+
+	TerminatorIndex = CurrentLineString.FindLastCharByPredicate(FText::IsWhitespace, Count);
+	if (TerminatorIndex != INDEX_NONE)
+	{
+		return TerminatorIndex;
+	}
+
+	return (Count - 1);
+}
+
+int UTypewriterTextWidget::CalculateMaxLength()
+{
+	int MaxLength = 0;
+	int CurrentNumberOfLines = 1;
+	for (int i = 0; i < Segments.Num(); i++)
+	{
+		const FTypewriterTextSegment& Segment = Segments[i];
+		if (Segment.Text.Equals(FString(TEXT("\n"))))
+		{
+			CurrentNumberOfLines++;
+			if (CurrentNumberOfLines > MaxNumberOfLines)
+			{
+				break;
+			}
+		}
+		else
+		{
+			MaxLength += Segment.Text.Len();
+		}
+	}
+
+	return MaxLength;
+}
+
+void UTypewriterTextWidget::CalculateWrappedString(const FString& CurrentLineString)
 {
 	// Rich Text views give you:
 	// - A blank block at the start for some reason
@@ -223,6 +295,9 @@ void UTypewriterTextWidget::CalculateWrappedString()
 	// - The newlines we add are the only newlines in the output so that's the number of lines
 	// If we've got here, that means the text isn't empty so 1 line at least
 	NumberOfLines = 1;
+	MaxLetterIndex = 0;
+	CombinedTextHeight = 0;
+	Segments.Empty();
 	if (IsValid(LineText) && LineText->GetTextLayout().IsValid())
 	{
 		TSharedPtr<FSlateTextLayout> Layout = LineText->GetTextLayout();
@@ -233,7 +308,7 @@ void UTypewriterTextWidget::CalculateWrappedString()
 
 		Layout->ClearLines();
 		Layout->SetWrappingWidth(TextBoxSize.X);
-		Marshaller->SetText(CurrentLine.ToString(), *Layout.Get());
+		Marshaller->SetText(CurrentLineString, *Layout.Get());
 		Layout->UpdateLayout();
 
 		bool bHasWrittenText = false;
@@ -299,7 +374,7 @@ void UTypewriterTextWidget::CalculateWrappedString()
 	}
 	else
 	{
-		Segments.Add(FTypewriterTextSegment{CurrentLine.ToString()});
+		Segments.Add(FTypewriterTextSegment{CurrentLineString});
 		MaxLetterIndex = Segments[0].Text.Len();
 	}
 

--- a/Source/StevesUEHelpers/Public/StevesUI/TypewriterTextWidget.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/TypewriterTextWidget.h
@@ -84,6 +84,10 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Typewriter")
 	float PauseTimeAtSentenceTerminators = 0.5f;
 
+	/// How many lines of text at most to print at once.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Typewriter")
+	int MaxNumberOfLines = 3;
+
 	/// Set Text immediately
 	UFUNCTION(BlueprintCallable)
 	void SetText(const FText& InText);
@@ -101,6 +105,12 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "Typewriter")
 	bool HasFinishedPlayingLine() const { return bHasFinishedPlaying; }
+
+	UFUNCTION(BlueprintCallable, Category = "Typewriter")
+	bool HasMoreLineParts() const { return bHasMoreLineParts; }
+
+	UFUNCTION(BlueprintCallable, Category = "Typewriter")
+	void PlayNextLinePart(float Speed = 1.0f);
 
 	UFUNCTION(BlueprintCallable, Category = "Typewriter")
 	void SkipToLineEnd();
@@ -127,15 +137,18 @@ protected:
 private:
 	void PlayNextLetter();
 	static bool IsSentenceTerminator(TCHAR Letter);
+	static bool IsClauseTerminator(TCHAR Letter);
+	static int FindLastTerminator(const FString& CurrentLineString, int Count);
 
-	void CalculateWrappedString();
+	int CalculateMaxLength();
+	void CalculateWrappedString(const FString& CurrentLineString);
 	FString CalculateSegments(FString* OutCurrentRunName);
 	void StartPlayLine();
 
 	UPROPERTY()
 	FText CurrentLine;
 
-	
+	FString RemainingLinePart;
 
 	struct FTypewriterTextSegment
 	{
@@ -158,6 +171,7 @@ private:
 	float CombinedTextHeight = 0;
 
 	uint32 bHasFinishedPlaying : 1;
+	uint32 bHasMoreLineParts : 1;
 
 	FTimerHandle LetterTimer;
 	float CurrentPlaySpeed = 1;


### PR DESCRIPTION
# Line splitting
Breaking overly long lines of text into multiple parts to avoid overflowing the text widget.

Requires a small change in the calling blueprint to support waiting for user input before advancing to the next part. Here's the [matching PR for SUDSExample](https://github.com/sinbad/SUDSExample/pull/2).

The reason to handle line splitting in the typewriter instead earlier in the SUDS chain is because only the typewriter knows the font and the size of the text box.

# Alternatives considered

## Manually
Manually breaking up overly long speaker lines in the `.sud` file into multiple lines with the same speaker.

Disadvantages:
1. very manual
2. breaks when resizing the text box
3. breaks when resizing the font
4. breaks when localizing to languages with longer words

## SUDS parser
Automatically breaking up overly long speaker lines in the `SUDSScriptImporter`.

Disadvantages:
1. all of the above except the first one
2. adds complexity for node indexing and `goto` resolution
3. breaks text ids (and therefore localization) when changing the split limit

## SUDS dialogue
Converting a `SUDSScript` into another `SUDSScript` with split speaker nodes when constructing the `SUDSDialog`. Probably feasible but rewiring the nodes seemed complex. Also not sure about localization and debugging. Handling it in the typewriter seemed easier.