### PR TITLE
Unfocus on Unhover for FocusableButton and FocusableCheckbox

### DIFF
--- a/Source/StevesUEHelpers/Private/StevesUI/FocusableButton.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/FocusableButton.cpp
@@ -130,7 +130,14 @@ void UFocusableButton::Unfocus() const
 			LocalPlayer->GetControllerId());
 		if (UserIndex.IsSet())
 		{
-			FSlateApplication::Get().ClearUserFocus(UserIndex.GetValue());
+			TSharedPtr<SWidget> SafeWidget = GetCachedWidget();
+			if (SafeWidget.IsValid())
+			{
+				if (SafeWidget->HasUserFocus(UserIndex.GetValue()))
+				{
+					FSlateApplication::Get().ClearUserFocus(UserIndex.GetValue());
+				}
+			}
 		}
 	}
 }

--- a/Source/StevesUEHelpers/Private/StevesUI/FocusableButton.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/FocusableButton.cpp
@@ -109,5 +109,28 @@ void UFocusableButton::SlateHandleHovered()
 
 void UFocusableButton::SlateHandleUnhovered()
 {
-    OnUnhovered.Broadcast();
+	if (bLoseFocusOnUnhover)
+	{
+		Unfocus();
+	}
+	OnUnhovered.Broadcast();
+}
+
+void UFocusableButton::Unfocus() const
+{
+	APlayerController* OwningPlayer = GetOwningPlayer();
+	if (OwningPlayer == nullptr || !OwningPlayer->IsLocalController() || OwningPlayer->Player ==
+		nullptr)
+	{
+		return;
+	}
+	if (ULocalPlayer* LocalPlayer = OwningPlayer->GetLocalPlayer())
+	{
+		TOptional<int32> UserIndex = FSlateApplication::Get().GetUserIndexForController(
+			LocalPlayer->GetControllerId());
+		if (UserIndex.IsSet())
+		{
+			FSlateApplication::Get().ClearUserFocus(UserIndex.GetValue());
+		}
+	}
 }

--- a/Source/StevesUEHelpers/Private/StevesUI/FocusableCheckBox.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/FocusableCheckBox.cpp
@@ -116,7 +116,14 @@ void UFocusableCheckBox::Unfocus() const
 			LocalPlayer->GetControllerId());
 		if (UserIndex.IsSet())
 		{
-			FSlateApplication::Get().ClearUserFocus(UserIndex.GetValue());
+			TSharedPtr<SWidget> SafeWidget = GetCachedWidget();
+			if (SafeWidget.IsValid())
+			{
+				if (SafeWidget->HasUserFocus(UserIndex.GetValue()))
+				{
+					FSlateApplication::Get().ClearUserFocus(UserIndex.GetValue());
+				}
+			}
 		}
 	}
 }

--- a/Source/StevesUEHelpers/Private/StevesUI/FocusableCheckBox.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/FocusableCheckBox.cpp
@@ -95,5 +95,28 @@ void UFocusableCheckBox::SlateHandleHovered()
 
 void UFocusableCheckBox::SlateHandleUnhovered()
 {
-    OnUnhovered.Broadcast();
+	if (bLoseFocusOnUnhover)
+	{
+		Unfocus();
+	}
+	OnUnhovered.Broadcast();
+}
+
+void UFocusableCheckBox::Unfocus() const
+{
+	APlayerController* OwningPlayer = GetOwningPlayer();
+	if (OwningPlayer == nullptr || !OwningPlayer->IsLocalController() || OwningPlayer->Player ==
+		nullptr)
+	{
+		return;
+	}
+	if (ULocalPlayer* LocalPlayer = OwningPlayer->GetLocalPlayer())
+	{
+		TOptional<int32> UserIndex = FSlateApplication::Get().GetUserIndexForController(
+			LocalPlayer->GetControllerId());
+		if (UserIndex.IsSet())
+		{
+			FSlateApplication::Get().ClearUserFocus(UserIndex.GetValue());
+		}
+	}
 }

--- a/Source/StevesUEHelpers/Public/StevesUI/FocusableButton.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/FocusableButton.h
@@ -38,6 +38,9 @@ public:
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
     bool bTakeFocusOnHover = true;
 
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    bool bLoseFocusOnUnhover = true;
+
     // Simulate a button press
     UFUNCTION(BlueprintCallable)
     void SimulatePress();
@@ -55,6 +58,8 @@ protected:
     void UndoFocusStyle();
     void SlateHandleHovered();
     void SlateHandleUnhovered();
+
+    void Unfocus() const;
 
     virtual TSharedRef<SWidget> RebuildWidget() override;
 

--- a/Source/StevesUEHelpers/Public/StevesUI/FocusableCheckBox.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/FocusableCheckBox.h
@@ -43,6 +43,10 @@ public:
     
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
 	bool bTakeFocusOnHover = true;
+
+	UPROPERTY(BlueprintReadWrite, EditAnywhere)
+	bool bLoseFocusOnUnhover = true;
+
 protected:    
 	FCheckBoxStyle FocussedStyle;
 
@@ -53,6 +57,8 @@ protected:
 	void UndoFocusStyle();
 	void SlateHandleHovered();
 	void SlateHandleUnhovered();
+
+	void Unfocus() const;
 
 	virtual TSharedRef<SWidget> RebuildWidget() override;
 


### PR DESCRIPTION
Add identical functionality for both `UFocusableButton` and `UFocusableCheckbox`:

- new property `bLoseFocusOnUnhover` (defaults to true)
- new function `Unfocus` which clears the current user focus.
- amended `SlateHandleUnhovered` to call `Unfocus` if `bLoseFocusOnUnhover` is `true`.

Tested against a simple UI and validated with the widget reflector on 5.4.

**Note:** UFocusableCheckbox doesn't have a distinct focused style by default so there is no visual change when it is focused or not.

Open questions:
- Inside of `Unfocus`, should we test if the currently focused widget is the widget that unfocus has been called on? It's protected right now, so I don't think it can be misused easily, but it still could technically clear the focus that's on a different widget.