### PR TITLE
Fix Crash When Changing Levels with Menu Open

### DIFF
--- a/Source/StevesUEHelpers/Private/StevesUI/MenuStack.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/MenuStack.cpp
@@ -299,10 +299,14 @@ void UMenuStack::LastMenuClosed(bool bWasCancel)
 void UMenuStack::CloseAll(bool bWasCancel)
 {
     // We don't go through normal pop sequence, this is a shot circuit
-    for (int i = Menus.Num() - 1; i >= 0; --i)
-    {
-        Menus[i]->RemovedFromStack(this);
-    }
+	for (int i = Menus.Num() - 1; i >= 0; --i)
+	{
+		UMenuBase* Menu = Menus[i];
+		if (IsValid(Menu))
+		{
+			Menus[i]->RemovedFromStack(this);
+		}
+	}
     Menus.Empty();
     LastMenuClosed(bWasCancel);
 }


### PR DESCRIPTION
When changing levels or ending PIE with a menu open, the for loop within `CloseAll` would crash, as it would be calling functions on Menus marked as unreachable. This fix prevents this by checking if the menu is valid before calling `RemoveFromStack` on it.