### PR TITLE
Tab widget

### DIFF
--- a/Source/StevesUEHelpers/Private/StevesUI/FocusablePanel.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/FocusablePanel.cpp
@@ -10,18 +10,18 @@ void UFocusablePanel::NativeConstruct()
     Super::NativeConstruct();
 
     // Find focus widget
-    if (!InitialFocusWidgetName.IsNone())
-    {
-        InitialFocusWidget = WidgetTree->FindWidget(InitialFocusWidgetName);
+    
+    InitialFocusWidget = GetInitialFocusWidget();
 #if WITH_EDITOR
-        if (!InitialFocusWidget.IsValid())
-        {
-            UE_LOG(LogStevesUI, Error, TEXT("Initial focus widget `%s` not found on %s, focus will be lost"), *InitialFocusWidgetName.ToString(), *GetName())
-        }
-#endif
+    if (!InitialFocusWidget.IsValid())
+    {
+        UE_LOG(LogStevesUI, Error, TEXT("Initial focus widget `%s` not found on %s, focus will be lost"), *InitialFocusWidgetName.ToString(), *GetName())
     }
+#endif
 
 }
+
+
 
 void UFocusablePanel::NativeDestruct()
 {
@@ -30,14 +30,28 @@ void UFocusablePanel::NativeDestruct()
     InitialFocusWidget.Reset();
 }
 
-bool UFocusablePanel::SetFocusToInitialWidget() const
+bool UFocusablePanel::SetFocusToInitialWidget()
 {
+    if (!InitialFocusWidget.IsValid())
+    {
+        // if not set, attempt to get
+        InitialFocusWidget = GetInitialFocusWidget();
+    }
     if (InitialFocusWidget.IsValid())
     {
         SetWidgetFocusProperly(InitialFocusWidget.Get());
         return true;
     }
     return false;
+}
+
+UWidget* UFocusablePanel::GetInitialFocusWidget_Implementation()
+{
+    if (!InitialFocusWidgetName.IsNone())
+    {
+        return WidgetTree->FindWidget(InitialFocusWidgetName);
+    }
+    return nullptr;
 }
 
 

--- a/Source/StevesUEHelpers/Private/StevesUI/TabButton.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/TabButton.cpp
@@ -1,0 +1,27 @@
+﻿#include "StevesUI/TabButton.h"
+
+void UTabButton::Initialise(int InTabIndex,const FText& InLabel)
+{
+	TabIndex=InTabIndex;
+	SetTabLabel(InLabel);
+}
+
+void UTabButton::SetTabLabel_Implementation(const FText& InLabel)
+{
+}
+
+void UTabButton::SetTabSelected(bool bSelected)
+{
+	bTabSelected=bSelected;
+	RefreshForSelectionChanged();
+}
+
+void UTabButton::RefreshForSelectionChanged_Implementation()
+{
+	
+}
+
+void UTabButton::NotifyTabSelected()
+{
+	OnTabSelected.Broadcast(TabIndex);
+}

--- a/Source/StevesUEHelpers/Private/StevesUI/TabListWidget.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/TabListWidget.cpp
@@ -1,0 +1,162 @@
+﻿#include "StevesUI/TabListWidget.h"
+#include "Components/HorizontalBoxSlot.h"
+#include "Components/WidgetSwitcher.h"
+#include "StevesUI/TabButton.h"
+#include "StevesUI/FocusableButton.h"
+#include "StevesUI/MenuBase.h"
+#include "Widgets/SPanel.h"
+
+
+void UTabListWidget::SetTargetWidgetSwitcher(UWidgetSwitcher* WidgetSwitcher)
+{
+	TargetWidgetSwitcher=WidgetSwitcher;
+}
+
+bool UTabListWidget::RegisterTab(const FName TabID, const TSubclassOf<UTabButton> ButtonWidgetType,FText Label,
+	UWidget* ContentWidget)
+{
+
+	if (RegisteredTabs.Contains(TabID))
+	{
+		UE_LOG(LogTemp,Error,TEXT("UTabListWidget::RegisterTab Already Registered ID %s"),*TabID.ToString());
+		return false;
+	}
+	if (TabButtonContainer==nullptr)
+	{
+		UE_LOG(LogTemp,Error,TEXT("UTabListWidget::RegisterTab TabButtonContainer is not set"));
+		return false;
+	}
+	FName const ButtonName( *FString::Printf(TEXT("TabButton_%s"),*TabID.ToString()));
+	UTabButton* const NewTabButton = Cast<UTabButton>(CreateWidget(this,ButtonWidgetType,ButtonName));
+	const int CurrentTabCount = RegisteredTabs.Num();
+	const int NewTabIndex = CurrentTabCount;
+	
+	FTabListRegisteredTabInfo TabInfo;
+	TabInfo.TabIndex = NewTabIndex;
+	TabInfo.TabButton = NewTabButton;
+	TabInfo.ContentInstance = ContentWidget;
+	RegisteredTabs.Add(TabID, TabInfo);
+	UPanelSlot* ButtonPanelSlot=TabButtonContainer->AddChild(NewTabButton);
+	UHorizontalBoxSlot* HorizontalBoxSlot=Cast<UHorizontalBoxSlot>(ButtonPanelSlot);
+	if (HorizontalBoxSlot)
+	{
+		HorizontalBoxSlot->SetPadding(TabButtonPadding);
+	}
+	
+	NewTabButton->OnTabSelected.AddUniqueDynamic(this,&UTabListWidget::TabPressed);
+	NewTabButton->TabIndex=NewTabIndex;
+	NewTabButton->Initialise(NewTabIndex,Label);
+
+	// If first tab added, select this
+	if (CurrentTabCount==0)
+	{
+		SelectTab(0);
+	}
+	return true;
+}
+
+void UTabListWidget::TabPressed(int TabIndex)
+{
+	SelectTab(TabIndex);
+}
+
+
+bool UTabListWidget::GetTabDataForIndex(const int Index,FTabListRegisteredTabInfo& TabInfo)
+{
+	for (const auto& InfoPair : RegisteredTabs)
+	{
+		if (InfoPair.Value.TabIndex==Index)
+		{
+			TabInfo=InfoPair.Value;
+			return true;
+		}
+	}
+	return false;
+}
+
+void UTabListWidget::IncrementTabIndex(int Amount)
+{
+	int NewTabIndex=SelectedTabIndex+Amount;
+	while (NewTabIndex<0) NewTabIndex+=RegisteredTabs.Num();
+	NewTabIndex%=RegisteredTabs.Num();
+	SelectTab(NewTabIndex);
+	
+}
+void UTabListWidget::SelectTab(int TabIndex)
+{
+	if (TabIndex==SelectedTabIndex) return; // No Change
+
+	// If a tab button has previously been selected, deselect
+	if (SelectedTabIndex!=-1)
+	{
+		FTabListRegisteredTabInfo PreviousTabInfo;
+		if (GetTabDataForIndex(SelectedTabIndex,PreviousTabInfo))
+		{
+			PreviousTabInfo.TabButton->SetTabSelected(false);
+		} else
+		{
+			UE_LOG(LogTemp,Warning,TEXT("Couldn't find button for previously index %i"),SelectedTabIndex);
+		}
+	}
+	SelectedTabIndex=TabIndex;
+	FTabListRegisteredTabInfo CurrentTabInfo;
+	if (GetTabDataForIndex(SelectedTabIndex,CurrentTabInfo))
+	{
+		CurrentTabInfo.TabButton->SetTabSelected(true);
+	}
+
+	if (!TargetWidgetSwitcher)
+	{
+		UE_LOG(LogTemp,Warning,TEXT("TargetWidgetSwitcher not set"));
+		return;
+	}
+	if (!CurrentTabInfo.ContentInstance)
+	{
+		UE_LOG(LogTemp,Warning,TEXT("Content not set for tab index %i"),SelectedTabIndex);
+		return;
+	}
+	
+	// If there is a current content widget, cache the current focus so that it can be restored when moving back to this tab
+	UWidget* PreviousContentWidget=TargetWidgetSwitcher->GetActiveWidget();
+	if (PreviousContentWidget)
+	{
+		if (UFocusablePanel* TargetFocusableWidget=Cast<UFocusablePanel>(PreviousContentWidget))
+		{
+			TargetFocusableWidget->SavePreviousFocus();
+		}
+	}
+	
+	TargetWidgetSwitcher->SetActiveWidget(CurrentTabInfo.ContentInstance);
+	
+	// If this is an instance of UFocusableUserWidget, notify to activate default focus
+	if (UFocusableUserWidget* TargetFocusableWidget=Cast<UFocusableUserWidget>(CurrentTabInfo.ContentInstance))
+	{
+		UE_LOG(LogTemp,Warning,TEXT("Focusable widget found for widget %s"),*CurrentTabInfo.ContentInstance->GetName());
+		TargetFocusableWidget->SetFocusProperly();
+	}else
+	{
+		UE_LOG(LogTemp,Warning,TEXT("Widget not focusable widget %s"),*CurrentTabInfo.ContentInstance->GetName());
+	}
+	// Notify
+	OnContentWidgetChanged.Broadcast(PreviousContentWidget,CurrentTabInfo.ContentInstance);
+}
+
+bool UTabListWidget::HandleKeyDownEvent(const FKeyEvent& InKeyEvent)
+{
+	Super::HandleKeyDownEvent(InKeyEvent);
+	
+	const FKey Key = InKeyEvent.GetKey();
+	if (PreviousTabKeys.Contains(Key))
+	{
+		IncrementTabIndex(-1);
+		return true;
+	}
+	if (NextTabKeys.Contains(Key))
+	{
+		IncrementTabIndex(1);
+		return true;
+	}
+	return false;
+}
+
+

--- a/Source/StevesUEHelpers/Public/StevesUI/FocusablePanel.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/FocusablePanel.h
@@ -30,8 +30,15 @@ public:
      * @return Whether the focus was successfully set
      */
     UFUNCTION(BlueprintCallable)
-    bool SetFocusToInitialWidget() const;
+    bool SetFocusToInitialWidget();
 
+    /**
+     * @brief Get's the desired focus widget. Allows implementation in BP for dynamically generated menus
+     * @return The initial focus widget
+     */
+    UFUNCTION(BlueprintNativeEvent)
+    UWidget* GetInitialFocusWidget();
+    
     /**
      * @brief Try to restore focus to the previously focussed child
      * @return Whether the focus was successfully set

--- a/Source/StevesUEHelpers/Public/StevesUI/TabButton.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/TabButton.h
@@ -1,0 +1,45 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "TabButton.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnTabSelected,int,TabIndex);
+
+/**
+ * Tab button - widget that is instantiated on a tab list
+ */
+UCLASS()
+class STEVESUEHELPERS_API UTabButton : public UUserWidget
+{
+	GENERATED_BODY()
+
+
+public:
+	
+	///
+	
+	UPROPERTY(BlueprintAssignable,BlueprintCallable)
+	FOnTabSelected OnTabSelected;
+	
+	UPROPERTY(BlueprintReadOnly)
+	int TabIndex;
+
+	UPROPERTY(BlueprintReadOnly)
+	bool bTabSelected=false;
+
+	void Initialise(int InTabIndex,const FText& InLabel);
+
+	UFUNCTION(BlueprintNativeEvent)
+	void SetTabLabel(const FText& InLabel);
+	
+	UFUNCTION(BlueprintCallable)
+	void SetTabSelected(bool bSelected);
+	
+	UFUNCTION(BlueprintCallable)
+	void NotifyTabSelected();
+
+	UFUNCTION(BlueprintNativeEvent)
+	void RefreshForSelectionChanged();
+	
+};

--- a/Source/StevesUEHelpers/Public/StevesUI/TabListWidget.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/TabListWidget.h
@@ -1,0 +1,110 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "StevesUI/FocusableInputInterceptorUserWidget.h"
+#include "TabListWidget.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnContentWidgetChanged,UWidget*,PreviousContentWidget,UWidget*,NewContentWidget);
+
+class UWidgetSwitcher;
+class UTabButton;
+/** Information about a registered tab in the tab list */
+USTRUCT()
+struct FTabListRegisteredTabInfo
+{
+	GENERATED_BODY()
+
+public:
+	/** The index of this tab */
+	UPROPERTY()
+	int32 TabIndex;
+	
+	/** The button for this tab */
+	UPROPERTY()
+	TObjectPtr<UTabButton> TabButton;
+
+	/** The content to be activated. */
+	UPROPERTY()
+	TObjectPtr<UWidget> ContentInstance;
+
+	FTabListRegisteredTabInfo()
+		: TabIndex(INDEX_NONE)
+		, TabButton(nullptr)
+		, ContentInstance(nullptr)
+	{}
+};
+
+
+/**
+ * Tab list widget - provides a tab selection bar that can control a widget switcher
+ */
+UCLASS()
+class STEVESUEHELPERS_API UTabListWidget : public UFocusableInputInterceptorUserWidget
+{
+	GENERATED_BODY()
+public:
+
+
+	/// Event called when tab content has changed
+	UPROPERTY(BlueprintCallable,BlueprintAssignable)
+	FOnContentWidgetChanged OnContentWidgetChanged;
+	
+	/// Input keys which navigate to the previous tab (left)
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Input")
+	TArray<FKey> PreviousTabKeys = TArray<FKey> { EKeys::Gamepad_LeftShoulder, EKeys::Q };
+	
+	/// Input keys which navigate to the next tab (right)
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Input")
+	TArray<FKey> NextTabKeys = TArray<FKey> { EKeys::Gamepad_RightShoulder, EKeys::E };
+
+	/// Map of tabs, buttons, content
+	TMap<FName,FTabListRegisteredTabInfo> RegisteredTabs;
+
+	// Where the tab buttons will be added
+	UPROPERTY(BlueprintReadWrite, meta = (BindWidget))
+	TObjectPtr<UPanelWidget> TabButtonContainer;
+	
+	UPROPERTY(BlueprintReadOnly)
+	int SelectedTabIndex=-1;
+
+	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	FMargin TabButtonPadding=FMargin(10,0);
+
+	UPROPERTY(BlueprintReadOnly)
+	UWidgetSwitcher* TargetWidgetSwitcher;
+	
+	/**
+	 * Registers tab content with this tab widget
+	 * @param TabID The ID to use for this widget
+	 * @param ButtonWidgetType The class of button to use
+	 * @param ContentWidget The widget to activate when pressed
+	 * @return True If successful
+	 */
+	UFUNCTION(BlueprintCallable, Category = TabList)
+	bool RegisterTab(FName TabID, TSubclassOf<UTabButton> ButtonWidgetType,FText Label, UWidget* ContentWidget);
+
+	/**
+	 * Called when a given tab button has been pressed
+	 * @param TabIndex 
+	 */
+	UFUNCTION()
+	void TabPressed(int TabIndex);
+
+	/**
+	 * Assign a widget switcher to be driven by this tab selection.
+	 * @param WidgetSwitcher 
+	 */
+	UFUNCTION(BlueprintCallable)
+	void SetTargetWidgetSwitcher(UWidgetSwitcher* WidgetSwitcher);
+
+	UFUNCTION(BlueprintCallable)
+	void IncrementTabIndex(int Amount);
+	
+	UFUNCTION(BlueprintCallable)
+	void SelectTab(int TabIndex);
+
+	virtual bool HandleKeyDownEvent(const FKeyEvent& InKeyEvent) override;
+
+private:
+	bool GetTabDataForIndex(int Index,FTabListRegisteredTabInfo& TabInfo);
+};


### PR DESCRIPTION
Added an implementation for a tab widget to support tab switching via a Widget Switcher. Attempts to restore focus when switching panels (if targetting a FocussablePanel).

Also includes a small change to FocussablePanel to allow for dynamically added widgets to be the initial focus widget.