### PR TITLE
Add a multi-line subtitle widget

### DIFF
--- a/Source/StevesUEHelpers/Private/StevesUI/MultiSubtitleTextblock.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/MultiSubtitleTextblock.cpp
@@ -1,0 +1,144 @@
+﻿//
+
+#include "StevesUI/MultiSubtitleTextblock.h"
+#include "Misc/DateTime.h"
+#include "SubtitleManager.h"
+
+TSharedRef<SWidget> UMultiSubtitleTextblock::RebuildWidget()
+{
+	auto Ret = Super::RebuildWidget();
+
+	if (!bSubscribed)
+	{
+		if (auto SM = FSubtitleManager::GetSubtitleManager())
+		{
+			SM->OnSetSubtitleText().AddUObject(this, &UMultiSubtitleTextblock::SetSubtitleText);
+			bSubscribed = true;
+		}
+	}
+
+	if (ConcurrentLines > 1)
+	{
+		if (!SubtitleUpdateTimer.IsValid() && GetWorld())
+		{
+			GetWorld()->GetTimerManager().SetTimer(
+				SubtitleUpdateTimer, this, &UMultiSubtitleTextblock::UpdateSubtitles, 1, true);
+		}
+
+		if (Subtitles.Num() != ConcurrentLines)
+		{
+			Subtitles.Empty();
+			Subtitles.Init({}, ConcurrentLines);
+		}
+	}
+
+	return Ret;
+}
+
+void UMultiSubtitleTextblock::BeginDestroy()
+{
+	Super::BeginDestroy();
+
+	if (bSubscribed)
+	{
+		if (auto SM = FSubtitleManager::GetSubtitleManager())
+		{
+			SM->OnSetSubtitleText().RemoveAll(this);
+			bSubscribed = false;
+		}
+	}
+
+	// Clear the timer if it has been set up
+	if (SubtitleUpdateTimer.IsValid() && GetWorld())
+	{
+		GetWorld()->GetTimerManager().ClearTimer(SubtitleUpdateTimer);
+	}
+}
+
+void UMultiSubtitleTextblock::SetSubtitleText(const FText& InText)
+{
+	// If the number of concurrent lines is such that the widget only ever 
+	// shows one subtitle at a time, just display it as-is
+	if (ConcurrentLines < 2)
+	{
+		SetText(InText);
+		return;
+	}
+
+	// When there is no sound playing that generates a subtitle, InText
+	// will be empty - let UpdateSubtitles() handle timing out
+	if (InText.IsEmptyOrWhitespace())
+		return;
+
+	bool bFoundMatch = false;
+	FString InString = InText.ToString();
+	uint64 Now = FDateTime::UtcNow().GetTicks();
+	
+	// Go through the displayed subtitle list looking for the current subtitle
+	// so its update time can be bumped if it exists in the list.
+	for (FSubtitleHistory& Entry : Subtitles)
+	{
+		if (Entry.Subtitle == InString)
+		{
+			bFoundMatch = true;
+			Entry.LastUpdate = Now;
+						
+			break;
+		}
+	}
+
+	// Subtitle isn't in the current list?
+	if (!bFoundMatch)
+	{
+		// Try to locate an entry in the list that isn't in use already, and
+		// update it to contain the current subtitle.
+		for (FSubtitleHistory& Entry : Subtitles)
+		{
+			if (Entry.Subtitle.IsEmpty())
+			{
+				bFoundMatch = true;
+				Entry.Subtitle = InString;
+				Entry.LastUpdate = Now;
+				break;
+			}
+		}
+
+		// Still not found a place to put the new subtitle? Replace the oldest
+		// subtitle in the list with the new one.
+		if (!bFoundMatch)
+		{
+			Subtitles.Sort();
+			FSubtitleHistory& Entry = Subtitles.Last();
+
+			Entry.Subtitle = InString;
+			Entry.LastUpdate = Now;
+		}
+	}
+
+	UpdateSubtitles();
+}
+
+void UMultiSubtitleTextblock::UpdateSubtitles()
+{ 
+	FString Contents;
+	uint64 Now = FDateTime::UtcNow().GetTicks();
+
+	Subtitles.Sort();
+
+	for (FSubtitleHistory& Entry : Subtitles)
+	{
+		// Remove subtitles that have timed out
+		if (!Entry.Subtitle.IsEmpty() &&
+			(Now - Entry.LastUpdate) > (MaximumAge * ETimespan::TicksPerMillisecond * 1000)) 
+		{
+			Entry.Subtitle = "";
+		}
+
+		if (!Entry.Subtitle.IsEmpty())
+		{
+			Contents += Entry.Subtitle + "\n";
+		}
+	}
+
+	SetText(FText::FromString(Contents));
+}

--- a/Source/StevesUEHelpers/Public/StevesUI/MultiSubtitleTextblock.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/MultiSubtitleTextblock.h
@@ -1,0 +1,70 @@
+﻿// 
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/TextBlock.h"
+#include "MultiSubtitleTextblock.generated.h"
+
+/**
+ * A text block that can show multiple lines of subtitles. The subtitles are
+ * displayed in the text box with the most recent line first, and subtitles
+ * time out after a configurable time once they stop being emitted by the
+ * engine.
+ * 
+ * NOTE: The implementation of this class is arguably quite horrible, as
+ * it relies on concatenating string versions of the subtitle texts. This is
+ * *almost certainly* going to cause problems with i18n. If you use this
+ * widget, expect it to not do the right thing with some languages!
+ * Don't blame Steve - this is all Jeremiah Fieldhaven's fault.
+ */
+UCLASS()
+class STEVESUEHELPERS_API UMultiSubtitleTextblock : public UTextBlock
+{
+	GENERATED_BODY()
+
+public:
+	virtual void BeginDestroy() override;
+
+	/// The number of subtitles that may be shown at any given time.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	uint8 ConcurrentLines = 1;
+
+	/// The length of time in seconds subtitles should remain in the block for.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	float MaximumAge = 4;
+
+protected:
+	bool bSubscribed;
+
+	void SetSubtitleText(const FText& Text);
+	virtual TSharedRef<SWidget> RebuildWidget() override;
+
+
+private:
+	/** Update the subtitle history list to remove timed-out lines, and
+	 * 	then set the contents of the text box to the new list of subtitles.
+	 */
+	void UpdateSubtitles();
+
+	struct FSubtitleHistory
+	{
+		FString Subtitle;
+		uint64 LastUpdate;
+
+		// Less than operator needed by TArray<> to sort the subtitles in
+		// order of update.
+		const bool operator<(const FSubtitleHistory& rhs) const
+		{
+			// Use > here to sort in reverse. The or ensures stability if two
+			// subtitles are playing simultaneously
+			return this->LastUpdate > rhs.LastUpdate || this->Subtitle < rhs.Subtitle;
+		}
+	};
+
+	// Handle for a timer that calls UpdateSubtitles() once per second
+	FTimerHandle SubtitleUpdateTimer;
+
+	// The list of subtitles to show in the widget
+	TArray<FSubtitleHistory> Subtitles;
+};


### PR DESCRIPTION
This adds a multi-line subtitle widget based on the SubtitleTextblock widget. The widget can be styled in the same way as the SubtitleTextblock, but this provides the option to show several lines of subtitles at once, and it handles timing out subtitles after they stop being emitted.

Please see the note in the header regarding potential i18n issues with this widget. I did consider trying to use FText throughout and a FText::Format to merge into one FText to go into the widget, instead of the current method, but was not convinced it would solve the fundamental issues with i18n.