### PR TITLE
UMenuStack improvements

### DIFF
--- a/Source/StevesUEHelpers/Private/StevesUI/MenuStack.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/MenuStack.cpp
@@ -292,6 +292,15 @@ UMenuBase* UMenuStack::GetTopMenu() const
     return nullptr;
 }
 
+UMenuBase* UMenuStack::GetPreviousMenu() const
+{
+	if (Menus.Num() > 1)
+	{
+		return Menus.Last(1);
+	}
+	return nullptr;
+}
+
 UMenuStack::UMenuStack():
 	LastInputMode(EInputMode::Unknown),
 	PreviousInputMode(EInputModeChange::GameOnly),

--- a/Source/StevesUEHelpers/Private/StevesUI/MenuStack.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/MenuStack.cpp
@@ -26,12 +26,6 @@ void UMenuStack::NativeConstruct()
     		GS->MoveMouseOffScreen(true);
     	}
     }
-
-    SavePreviousInputMousePauseState();
-
-    ApplyInputModeChange(InputModeSettingOnOpen);
-    ApplyMousePointerVisibility(MousePointerVisibilityOnOpen);
-    ApplyGamePauseChange(GamePauseSettingOnOpen);
 }
 
 void UMenuStack::NativeDestruct()
@@ -268,6 +262,12 @@ void UMenuStack::FirstMenuOpened()
 	{
 		AddToViewport();
 	}
+	
+	SavePreviousInputMousePauseState();
+	
+	ApplyInputModeChange(InputModeSettingOnOpen);
+	ApplyMousePointerVisibility(MousePointerVisibilityOnOpen);
+	ApplyGamePauseChange(GamePauseSettingOnOpen);
 }
 
 void UMenuStack::RemoveFromParent()

--- a/Source/StevesUEHelpers/Public/StevesUI/MenuStack.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/MenuStack.h
@@ -34,7 +34,8 @@ protected:
     EInputModeChange PreviousInputMode;
     EMousePointerVisibilityChange PreviousMouseVisibility;
     EGamePauseChange PreviousPauseState;
-    
+
+	UPROPERTY()
     TArray<UMenuBase*> Menus;
 
     virtual void FirstMenuOpened();

--- a/Source/StevesUEHelpers/Public/StevesUI/MenuStack.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/MenuStack.h
@@ -149,7 +149,10 @@ public:
 
     /// Return the menu which is currently top of the stack
     UFUNCTION(BlueprintCallable)
-    UMenuBase* GetTopMenu() const;
+	UMenuBase* GetTopMenu() const;
+	/// Return the menu which is currently right below the top of the stack
+	UFUNCTION(BlueprintCallable)
+	UMenuBase* GetPreviousMenu() const;
 
     UMenuStack();
 


### PR DESCRIPTION
- The Menus TArray is now a UPROPERTY to avoid menus getting GC'd
- Input Mode, Mouse Pointer and Game Pause Apply functions have been moved from `NativeConstruct` to `FirstMenuOpened`, allowing the MenuStack to remain in the viewport and still have consistent input behavior.
- Added a `GetPreviousMenu` function to access the menu right below the Top Menu for use in transitions (I use this in the video to figure out if the previous menu I'm transitioning to has bars showing)

https://github.com/user-attachments/assets/46817084-82a2-43af-85ea-5f524a77296d

