### PR TITLE
Add a vbox that permits several subtitles to appear simultaneously

### DIFF
--- a/Source/StevesUEHelpers/Private/StevesUI/MultiSubtitleVerticalbox.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/MultiSubtitleVerticalbox.cpp
@@ -1,0 +1,182 @@
+﻿// 
+
+
+#include "StevesUI/MultiSubtitleVerticalbox.h"
+
+#include "SubtitleManager.h"
+#include "Engine/Font.h"
+#include "Kismet/GameplayStatics.h"
+
+
+TSharedRef<SWidget> UMultiSubtitleVerticalbox::RebuildWidget()
+{
+	auto Ret = Super::RebuildWidget();
+
+	if (!bSubscribed)
+	{
+		if (auto SM = FSubtitleManager::GetSubtitleManager())
+		{
+			SM->OnSetSubtitleText().AddUObject(this, &UMultiSubtitleVerticalbox::SetSubtitleText);
+			bSubscribed = true;
+		}
+	}
+
+	if (!SubtitleUpdateTimer.IsValid() && GetWorld())
+	{
+		GetWorld()->GetTimerManager().SetTimer(
+			SubtitleUpdateTimer, this, &UMultiSubtitleVerticalbox::UpdateSubtitles, 1, true);
+	}
+
+	if (ConcurrentLines != TextBlocks.Num())
+	{
+		// If there aren't enough textblocks in the vertical box, add some
+		while (TextBlocks.Num() < ConcurrentLines)
+		{
+			TextBlocks.Add(CreateTextBlock());
+		}
+
+		// If there are too many, remove them and mark them for cleanup
+		while (TextBlocks.Num() > ConcurrentLines)
+		{
+			TObjectPtr<UTextBlock> Last = TextBlocks.Pop();
+			
+			if (Last != nullptr)
+			{
+				RemoveChild(Last);
+				Last->MarkAsGarbage();
+			}
+		}
+	}
+
+	// Recreate the subtitles list if needed
+	if (ConcurrentLines != Subtitles.Num())
+	{
+		Subtitles.Empty();
+		Subtitles.Init({}, ConcurrentLines);
+	}
+	
+	return Ret;
+}
+
+
+void UMultiSubtitleVerticalbox::BeginDestroy()
+{
+	Super::BeginDestroy();
+
+	if (bSubscribed)
+	{
+		if (auto SM = FSubtitleManager::GetSubtitleManager())
+		{
+			SM->OnSetSubtitleText().RemoveAll(this);
+			bSubscribed = false;
+		}
+	}
+
+	// Clear the timer if it has been set up
+	if (SubtitleUpdateTimer.IsValid() && GetWorld())
+	{
+		GetWorld()->GetTimerManager().ClearTimer(SubtitleUpdateTimer);
+	}
+}
+
+
+TObjectPtr<UTextBlock> UMultiSubtitleVerticalbox::CreateTextBlock()
+{ 
+	TObjectPtr<UTextBlock> NewBlock = NewObject<UTextBlock>(this);
+
+	if (NewBlock != nullptr)
+	{
+		// Copy the style settings over
+		NewBlock->SetColorAndOpacity(ColorAndOpacity);
+		NewBlock->SetMinDesiredWidth(MinDesiredWidth);
+		NewBlock->SetFont(Font);
+		NewBlock->SetStrikeBrush(StrikeBrush);
+		NewBlock->SetShadowOffset(ShadowOffset);
+		NewBlock->SetShadowColorAndOpacity(ShadowColorAndOpacity);
+
+		AddChildToVerticalBox(NewBlock);
+
+		return NewBlock;
+	}
+	return nullptr; 
+}
+
+
+void UMultiSubtitleVerticalbox::SetSubtitleText(const FText& InText)
+{
+	// When there is no sound playing that generates a subtitle, InText
+	// will be empty - let UpdateSubtitles() handle timing out
+	if (InText.IsEmptyOrWhitespace())
+		return;
+
+	bool bFoundMatch = false;
+	uint64 Now = FDateTime::UtcNow().GetTicks();
+
+	// Go through the displayed subtitle list looking for the current subtitle
+	// so its update time can be bumped if it exists in the list.
+	for (FSubtitleHistory& Entry : Subtitles)
+	{
+		if (Entry.Subtitle.EqualTo(InText))
+		{
+			bFoundMatch = true;
+			Entry.LastUpdate = Now;
+			break;
+		}
+	}
+
+	if (!bFoundMatch)
+	{
+		// Try to locate an entry in the list that isn't in use already, and
+		// update it to contain the current subtitle.
+		for (FSubtitleHistory& Entry : Subtitles)
+		{
+			if (Entry.Subtitle.IsEmpty())
+			{
+				bFoundMatch = true;
+				Entry.Subtitle = InText;
+				Entry.LastUpdate = Now;
+				break;
+			}
+		}	
+
+		// Still not found a place to put the new subtitle? Replace the oldest
+		// subtitle in the list with the new one.
+		if (!bFoundMatch)
+		{
+			Subtitles.Sort();
+			FSubtitleHistory& Entry = Subtitles.Last();
+
+			Entry.Subtitle = InText;
+			Entry.LastUpdate = Now;
+		}
+
+		UpdateSubtitles();
+	}
+}
+
+
+void UMultiSubtitleVerticalbox::UpdateSubtitles() 
+{
+	uint64 Now = FDateTime::UtcNow().GetTicks();
+
+	// Handle timeout of subtitles that haven't been updated recently
+	for (FSubtitleHistory& Entry : Subtitles)
+	{
+		if (!Entry.Subtitle.IsEmpty() &&
+			(Now - Entry.LastUpdate) > (MaximumAge * ETimespan::TicksPerMillisecond * 1000))
+		{
+			Entry.Subtitle = FText::GetEmpty();
+		}
+	}
+
+	Subtitles.Sort();
+
+	// Update the list of textblocks with the subtitle texts
+	for (int i = 0; i < TextBlocks.Num(); ++i)
+	{
+		if (TextBlocks[i] != nullptr && i < Subtitles.Num())
+		{
+			TextBlocks[i]->SetText(Subtitles[i].Subtitle);
+		}
+	}
+}

--- a/Source/StevesUEHelpers/Public/StevesUI/MultiSubtitleVerticalbox.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/MultiSubtitleVerticalbox.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/VerticalBox.h"
+#include "Components/TextBlock.h"
+#include "MultiSubtitleVerticalbox.generated.h"
+
+
+/**
+ * A text block that can show multiple lines of subtitles. The subtitles are
+ * displayed in the text box with the most recent line first, and subtitles
+ * time out after a configurable time once they stop being emitted by the
+ * engine.
+ */
+UCLASS()
+class STEVESUEHELPERS_API UMultiSubtitleVerticalbox : public UVerticalBox
+{
+	GENERATED_BODY()
+
+public:
+	/// The number of subtitles that may be shown at any given time.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "1.0"), Category = "Subtitles")
+	uint8 ConcurrentLines = 1;
+
+	/// The length of time in seconds subtitles should remain in the block for.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = ( ClampMin = "1.0" ), Category = "Subtitles")
+	float MaximumAge = 4;
+
+	/** The color of the text shown in child text boxes */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Textbox Appearance")
+	FSlateColor ColorAndOpacity = FLinearColor::White;
+	;
+
+	/** The minimum desired size for the text in child text boxes */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Textbox Appearance")
+	float MinDesiredWidth;
+
+	/** The font to render the text with in child text boxes */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Textbox Appearance")
+	FSlateFontInfo Font;
+
+	/** The brush to strike through text with in child text boxes */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Textbox Appearance")
+	FSlateBrush StrikeBrush;
+
+	/** The direction the shadow is cast in child text boxes */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Textbox Appearance")
+	FVector2D ShadowOffset = FVector2D(1.0f, 1.0f);
+
+	/** The color of the shadow in child text boxes */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Textbox Appearance", meta = (DisplayName = "Shadow Color"))
+	FLinearColor ShadowColorAndOpacity = FLinearColor::Transparent;
+
+	virtual void BeginDestroy() override;
+
+protected:
+	bool bSubscribed;
+
+	void SetSubtitleText(const FText& Text);
+	virtual TSharedRef<SWidget> RebuildWidget() override;
+
+	struct FSubtitleHistory
+	{
+		FText  Subtitle;
+		uint64 LastUpdate;
+
+		// Less than operator needed by TArray<> to sort the subtitles in
+		// order of update.
+		const bool operator<(const FSubtitleHistory& rhs) const
+		{
+			// Use > here to sort in reverse. The or ensures stability if two
+			// subtitles are playing simultaneously
+			return !this -> Subtitle.IsEmpty() && (this->LastUpdate > rhs.LastUpdate || this->Subtitle.CompareTo(rhs.Subtitle) < 0);
+		}
+	};
+
+	/** Create a new TextBlock widget and add it to the vertical box. This will
+	 *  copy the 'Textbox Appearance' settings across into the new text block
+	 *  before adding it to the vertical box.
+	 * 
+	 * @return A pointer to the newly created TextBlock, or nullptr on error
+	 */
+	TObjectPtr<UTextBlock> CreateTextBlock();
+
+	/** Update the subtitle history list to remove timed-out lines, and
+	 * 	then set the contents of the text box to the new list of subtitles.
+	 */
+	void UpdateSubtitles();
+
+	// Handle for a timer that calls UpdateSubtitles() once per second
+	FTimerHandle SubtitleUpdateTimer;
+
+	// The list of text blocks in the widget
+	TArray<TObjectPtr<UTextBlock>> TextBlocks;
+
+	// The list of subtitles to show
+	TArray<FSubtitleHistory> Subtitles;
+};


### PR DESCRIPTION
This is intended to aid in showing multiple subtitles at the same time to improve accessibility for players who have hearing issues: with the default subtitle display, only one subtitle is shown at once, even if more than one potentially meaningful sound is playing. This allows several lines of subtitle to appear simultaneously so that potentially important sound indicators are not lost.