### PR TITLE
UMenuStack: Add a BeforeFirstMenuOpened function

### DIFF
--- a/Source/StevesUEHelpers/Private/StevesUI/MenuStack.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/MenuStack.cpp
@@ -211,9 +211,14 @@ void UMenuStack::PushMenuByObject(UMenuBase* NewMenu)
         // We keep this allocated, to restore later on back
     }
     Menus.Add(NewMenu);
+	bool IsFirstMenu = Menus.Num() == 1;
+	
+	if (IsFirstMenu)
+		BeforeFirstMenuOpened();
+	
     NewMenu->AddedToStack(this);
 
-    if (Menus.Num() == 1)
+    if (IsFirstMenu)
         FirstMenuOpened();
 }
 
@@ -253,6 +258,15 @@ void UMenuStack::PopMenuIfTop(UMenuBase* UiMenuBase, bool bWasCancel)
 }
 
 
+void UMenuStack::BeforeFirstMenuOpened()
+{
+	SavePreviousInputMousePauseState();
+	
+	ApplyInputModeChange(InputModeSettingOnOpen);
+	ApplyMousePointerVisibility(MousePointerVisibilityOnOpen);
+	ApplyGamePauseChange(GamePauseSettingOnOpen);
+}
+
 void UMenuStack::FirstMenuOpened()
 {
     // Don't use world time (even real time) since map can change while open
@@ -262,12 +276,6 @@ void UMenuStack::FirstMenuOpened()
 	{
 		AddToViewport();
 	}
-	
-	SavePreviousInputMousePauseState();
-	
-	ApplyInputModeChange(InputModeSettingOnOpen);
-	ApplyMousePointerVisibility(MousePointerVisibilityOnOpen);
-	ApplyGamePauseChange(GamePauseSettingOnOpen);
 }
 
 void UMenuStack::RemoveFromParent()

--- a/Source/StevesUEHelpers/Public/StevesUI/MenuStack.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/MenuStack.h
@@ -38,6 +38,7 @@ protected:
 	UPROPERTY()
     TArray<UMenuBase*> Menus;
 
+	virtual void BeforeFirstMenuOpened();
     virtual void FirstMenuOpened();
     virtual void LastMenuClosed(bool bWasCancel);
 


### PR DESCRIPTION
Not much I have to say about this one, I realized after yesterday's PR that Menus with their own Input Mode, etc. settings would do their thing first before the MenuStack is able to save previous settings.