### PR TITLE
Added functionality to clear previously registered Input Action Interests

### DIFF
--- a/Source/StevesUEHelpers/Private/StevesGameSubsystem.cpp
+++ b/Source/StevesUEHelpers/Private/StevesGameSubsystem.cpp
@@ -134,6 +134,26 @@ void UStevesGameSubsystem::RegisterInterestInEnhancedInputAction(const UInputAct
     
 }
 
+void UStevesGameSubsystem::UnregisterAllInterestInEnhancedInputActions()
+{
+    if (auto GI = GetGameInstance())
+    {
+        if (auto PC = GI->GetFirstLocalPlayerController())
+        {
+            if (auto EIC = Cast<UEnhancedInputComponent>(PC->InputComponent))
+            {
+                for (int i = 0; i < EIC->GetActionEventBindings().Num(); i++) {
+                    if (EIC->GetActionEventBindings()[i].Get()->GetUObject()==this)
+                    {
+                        EIC->RemoveBindingByHandle(EIC->GetActionEventBindings()[i]->GetHandle());
+                    }
+                }
+            }
+        }
+    }
+    RegisteredEnhancedInputActionInterests.Empty();
+}
+
 void UStevesGameSubsystem::EnhancedInputActionTriggered(const FInputActionInstance& InputActionInstance)
 {
     OnEnhancedInputActionTriggered.Broadcast(InputActionInstance.GetSourceAction(), InputActionInstance.GetTriggerEvent());

--- a/Source/StevesUEHelpers/Public/StevesGameSubsystem.h
+++ b/Source/StevesUEHelpers/Public/StevesGameSubsystem.h
@@ -343,6 +343,11 @@ public:
     UFUNCTION(BlueprintCallable, Category="StevesGameSubsystem")
     void RegisterInterestInEnhancedInputAction(const UInputAction* Action, ETriggerEvent TriggerEvent);
 
+     // Unregister all previously registered interests in input actions. This can be needed if a new scene is loaded, as previously
+    // regsitered InputActions will no longer fire
+    UFUNCTION(BlueprintCallable)
+    void UnregisterAllInterestInEnhancedInputActions();
+
 	/// Moves the mouse pointer offscreen so that it can't trigger hovers on anything. This happens by
 	/// default when switching to gamepad mode, but in edge cases I've found it useful to ensure that
 	/// some other effect doesn't interfere with gamepad navigation by relocating the mouse pointer to


### PR DESCRIPTION
When loading scenes, registered input actions no longer fire. This method clears previously registered action interests, allowing them to be registered again.