### PR TITLE
Tab Widget - Ignore button presses if disabled

### DIFF
--- a/Source/StevesUEHelpers/Private/StevesUI/TabListWidget.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/TabListWidget.cpp
@@ -146,6 +146,7 @@ void UTabListWidget::SelectTab(int TabIndex)
 bool UTabListWidget::HandleKeyDownEvent(const FKeyEvent& InKeyEvent)
 {
 	Super::HandleKeyDownEvent(InKeyEvent);
+	if (!this->GetIsEnabled()) return false;  // Ignore if not enabled
 	
 	const FKey Key = InKeyEvent.GetKey();
 	if (PreviousTabKeys.Contains(Key))


### PR DESCRIPTION
Ignore presses for tab if disabled (so can be disabled if superceded)