### PR TITLE
Add the option to disable rather than hide up/down widgets in OptionWidgetBase

### DIFF
--- a/Source/StevesUEHelpers/Private/StevesUI/OptionWidgetBase.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/OptionWidgetBase.cpp
@@ -44,10 +44,10 @@ void UOptionWidgetBase::NativeConstruct()
     if (!GamepadDownImage)
         UE_LOG(LogStevesUI, Error, TEXT("%s should have a GamepadDownImage instance."), *this->GetClass()->GetName());
 
-    if (bDisableAtLimit && !GamepadUpImageDisabled)
-        UE_LOG(LogStevesUI, Error, TEXT("%s should have a GamepadUpImageDisabled instance."), *this->GetClass()->GetName());
-    if (bDisableAtLimit && !GamepadDownImageDisabled)
-        UE_LOG(LogStevesUI, Error, TEXT("%s should have a GamepadDownImageDisabled instance."), *this->GetClass()->GetName());
+    if (bDisableAtLimit && !GamepadUpDisabledImage)
+        UE_LOG(LogStevesUI, Error, TEXT("%s should have a GamepadUpDisabledImage instance."), *this->GetClass()->GetName());
+    if (bDisableAtLimit && !GamepadDownDisabledImage)
+        UE_LOG(LogStevesUI, Error, TEXT("%s should have a GamepadDownDisabledImage instance."), *this->GetClass()->GetName());
 
     SynchronizeProperties();
 
@@ -193,10 +193,10 @@ void UOptionWidgetBase::UpdateUpDownButtons()
         if (MouseUpButton)
             MouseUpButton->SetIsEnabled(CanIncrease);
 
-        if (GamepadDownImageDisabled)
-            GamepadDownImageDisabled->SetVisibility(CanDecrease ? ESlateVisibility::Hidden : ESlateVisibility::Visible);
-        if (GamepadUpImageDisabled)
-            GamepadUpImageDisabled->SetVisibility(CanIncrease ? ESlateVisibility::Hidden : ESlateVisibility::Visible);
+        if (GamepadDownDisabledImage)
+            GamepadDownDisabledImage->SetVisibility(CanDecrease ? ESlateVisibility::Hidden : ESlateVisibility::Visible);
+        if (GamepadUpDisabledImage)
+            GamepadUpDisabledImage->SetVisibility(CanIncrease ? ESlateVisibility::Hidden : ESlateVisibility::Visible);
 
     } else {
         if (MouseDownButton)
@@ -205,10 +205,10 @@ void UOptionWidgetBase::UpdateUpDownButtons()
             MouseUpButton->SetVisibility(CanIncrease ? ESlateVisibility::Visible : ESlateVisibility::Hidden);
 
         // When DisableAtLimit is not set, we never want to show the Disabled images
-        if (GamepadDownImageDisabled)
-            GamepadDownImageDisabled->SetVisibility(ESlateVisibility::Hidden);
-        if (GamepadUpImageDisabled)
-            GamepadUpImageDisabled->SetVisibility(ESlateVisibility::Hidden);
+        if (GamepadDownDisabledImage)
+            GamepadDownDisabledImage->SetVisibility(ESlateVisibility::Hidden);
+        if (GamepadUpDisabledImage)
+            GamepadUpDisabledImage->SetVisibility(ESlateVisibility::Hidden);
     }
 
     if (GamepadDownImage)

--- a/Source/StevesUEHelpers/Private/StevesUI/OptionWidgetBase.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/OptionWidgetBase.cpp
@@ -44,6 +44,10 @@ void UOptionWidgetBase::NativeConstruct()
     if (!GamepadDownImage)
         UE_LOG(LogStevesUI, Error, TEXT("%s should have a GamepadDownImage instance."), *this->GetClass()->GetName());
 
+    if (bDisableAtLimit && !GamepadUpImageDisabled)
+        UE_LOG(LogStevesUI, Error, TEXT("%s should have a GamepadUpImageDisabled instance."), *this->GetClass()->GetName());
+    if (bDisableAtLimit && !GamepadDownImageDisabled)
+        UE_LOG(LogStevesUI, Error, TEXT("%s should have a GamepadDownImageDisabled instance."), *this->GetClass()->GetName());
 
     SynchronizeProperties();
 
@@ -182,10 +186,31 @@ void UOptionWidgetBase::UpdateUpDownButtons()
 {
     const bool CanDecrease = SelectedIndex > 0;
     const bool CanIncrease = SelectedIndex < Options.Num() - 1;
-    if (MouseDownButton)
-        MouseDownButton->SetVisibility(CanDecrease ? ESlateVisibility::Visible : ESlateVisibility::Hidden);
-    if (MouseUpButton)
-        MouseUpButton->SetVisibility(CanIncrease ? ESlateVisibility::Visible : ESlateVisibility::Hidden);
+
+    if(bDisableAtLimit) {
+        if (MouseDownButton)
+            MouseDownButton->SetIsEnabled(CanDecrease);
+        if (MouseUpButton)
+            MouseUpButton->SetIsEnabled(CanIncrease);
+
+        if (GamepadDownImageDisabled)
+            GamepadDownImageDisabled->SetVisibility(CanDecrease ? ESlateVisibility::Hidden : ESlateVisibility::Visible);
+        if (GamepadUpImageDisabled)
+            GamepadUpImageDisabled->SetVisibility(CanIncrease ? ESlateVisibility::Hidden : ESlateVisibility::Visible);
+
+    } else {
+        if (MouseDownButton)
+            MouseDownButton->SetVisibility(CanDecrease ? ESlateVisibility::Visible : ESlateVisibility::Hidden);
+        if (MouseUpButton)
+            MouseUpButton->SetVisibility(CanIncrease ? ESlateVisibility::Visible : ESlateVisibility::Hidden);
+
+        // When DisableAtLimit is not set, we never want to show the Disabled images
+        if (GamepadDownImageDisabled)
+            GamepadDownImageDisabled->SetVisibility(ESlateVisibility::Hidden);
+        if (GamepadUpImageDisabled)
+            GamepadUpImageDisabled->SetVisibility(ESlateVisibility::Hidden);
+    }
+
     if (GamepadDownImage)
         GamepadDownImage->SetVisibility(CanDecrease ? ESlateVisibility::Visible : ESlateVisibility::Hidden);
     if (GamepadUpImage)

--- a/Source/StevesUEHelpers/Public/StevesUI/OptionWidgetBase.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/OptionWidgetBase.h
@@ -51,10 +51,10 @@ public:
     TObjectPtr<UImage> GamepadDownImage;    
 
     UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (BindWidget), Category="OptionWidget")
-    TObjectPtr<UImage> GamepadUpImageDisabled;
+    TObjectPtr<UImage> GamepadUpDisabledImage;
 
     UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (BindWidget), Category="OptionWidget")
-    TObjectPtr<UImage> GamepadDownImageDisabled;
+    TObjectPtr<UImage> GamepadDownDisabledImage;
 
     UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (BindWidget), Category="OptionWidget")
     TObjectPtr<UTextBlock> GamepadText;
@@ -108,7 +108,7 @@ protected:
 
     /// Whether this option widget should set the up/down widgets to disabled at
     /// the end of the range
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Behavior")
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="OptionWidget")
     bool bDisableAtLimit = false;
 
     UFUNCTION(BlueprintCallable, Category="OptionWidget")

--- a/Source/StevesUEHelpers/Public/StevesUI/OptionWidgetBase.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/OptionWidgetBase.h
@@ -51,6 +51,12 @@ public:
     TObjectPtr<UImage> GamepadDownImage;    
 
     UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (BindWidget), Category="OptionWidget")
+    TObjectPtr<UImage> GamepadUpImageDisabled;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (BindWidget), Category="OptionWidget")
+    TObjectPtr<UImage> GamepadDownImageDisabled;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (BindWidget), Category="OptionWidget")
     TObjectPtr<UTextBlock> GamepadText;
 
     /// Event raised when the selected option changes
@@ -99,6 +105,11 @@ protected:
     TArray<FText> Options;
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category=Content)
     int SelectedIndex;
+
+    /// Whether this option widget should set the up/down widgets to disabled at
+    /// the end of the range
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Behavior")
+    bool bDisableAtLimit = false;
 
     UFUNCTION(BlueprintCallable, Category="OptionWidget")
     virtual void SetMouseMode();


### PR DESCRIPTION
Adds a `bDisableAtLimit` flag and support for "disabled" images for Gamepad display to the OptionWidgetBase class.

If `bDisableAtLimit` is false (the default, to ensure it does not interfere with existing widgets), the behaviour of the OptionWidgetBase class is unchanged, and the gamepad "disabled" images are not required to be set for the widget.

If `bDisableAtLimit` is true, the behaviour of the widget is changed so that:
* Gamepad "disabled" images should be provided.
* for mouse input, the down and up widgets are disabled at the start or end of the list rather than hidden.
* for gamepad input, the down and up images are hidden when at the start or end of the list, but the appropriate "disabled" version is made visible.
