### PR TITLE
Add support for disabling up/down widgets at end of range

### DIFF
--- a/Source/StevesUEHelpers/Private/StevesUI/OptionWidgetBase.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/OptionWidgetBase.cpp
@@ -44,10 +44,11 @@ void UOptionWidgetBase::NativeConstruct()
     if (!GamepadDownImage)
         UE_LOG(LogStevesUI, Error, TEXT("%s should have a GamepadDownImage instance."), *this->GetClass()->GetName());
 
+	// Log the absence of disabled gamepad images, rather than showing an error
     if (bDisableAtLimit && !GamepadUpDisabledImage)
-        UE_LOG(LogStevesUI, Error, TEXT("%s should have a GamepadUpDisabledImage instance."), *this->GetClass()->GetName());
+        UE_LOG(LogStevesUI, Log, TEXT("%s does not have a GamepadUpDisabledImage instance."), *this->GetClass()->GetName());
     if (bDisableAtLimit && !GamepadDownDisabledImage)
-        UE_LOG(LogStevesUI, Error, TEXT("%s should have a GamepadDownDisabledImage instance."), *this->GetClass()->GetName());
+        UE_LOG(LogStevesUI, Log, TEXT("%s does not have a GamepadDownDisabledImage instance."), *this->GetClass()->GetName());
 
     SynchronizeProperties();
 

--- a/Source/StevesUEHelpers/Private/StevesUI/OptionWidgetBase.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/OptionWidgetBase.cpp
@@ -44,6 +44,10 @@ void UOptionWidgetBase::NativeConstruct()
     if (!GamepadDownImage)
         UE_LOG(LogStevesUI, Error, TEXT("%s should have a GamepadDownImage instance."), *this->GetClass()->GetName());
 
+    if (bDisableAtLimit && !GamepadUpDisabledImage)
+        UE_LOG(LogStevesUI, Error, TEXT("%s should have a GamepadUpDisabledImage instance."), *this->GetClass()->GetName());
+    if (bDisableAtLimit && !GamepadDownDisabledImage)
+        UE_LOG(LogStevesUI, Error, TEXT("%s should have a GamepadDownDisabledImage instance."), *this->GetClass()->GetName());
 
     SynchronizeProperties();
 
@@ -182,10 +186,31 @@ void UOptionWidgetBase::UpdateUpDownButtons()
 {
     const bool CanDecrease = SelectedIndex > 0;
     const bool CanIncrease = SelectedIndex < Options.Num() - 1;
-    if (MouseDownButton)
-        MouseDownButton->SetVisibility(CanDecrease ? ESlateVisibility::Visible : ESlateVisibility::Hidden);
-    if (MouseUpButton)
-        MouseUpButton->SetVisibility(CanIncrease ? ESlateVisibility::Visible : ESlateVisibility::Hidden);
+
+    if(bDisableAtLimit) {
+        if (MouseDownButton)
+            MouseDownButton->SetIsEnabled(CanDecrease);
+        if (MouseUpButton)
+            MouseUpButton->SetIsEnabled(CanIncrease);
+
+        if (GamepadDownDisabledImage)
+            GamepadDownDisabledImage->SetVisibility(CanDecrease ? ESlateVisibility::Hidden : ESlateVisibility::Visible);
+        if (GamepadUpDisabledImage)
+            GamepadUpDisabledImage->SetVisibility(CanIncrease ? ESlateVisibility::Hidden : ESlateVisibility::Visible);
+
+    } else {
+        if (MouseDownButton)
+            MouseDownButton->SetVisibility(CanDecrease ? ESlateVisibility::Visible : ESlateVisibility::Hidden);
+        if (MouseUpButton)
+            MouseUpButton->SetVisibility(CanIncrease ? ESlateVisibility::Visible : ESlateVisibility::Hidden);
+
+        // When DisableAtLimit is not set, we never want to show the Disabled images
+        if (GamepadDownDisabledImage)
+            GamepadDownDisabledImage->SetVisibility(ESlateVisibility::Hidden);
+        if (GamepadUpDisabledImage)
+            GamepadUpDisabledImage->SetVisibility(ESlateVisibility::Hidden);
+    }
+
     if (GamepadDownImage)
         GamepadDownImage->SetVisibility(CanDecrease ? ESlateVisibility::Visible : ESlateVisibility::Hidden);
     if (GamepadUpImage)

--- a/Source/StevesUEHelpers/Public/StevesUI/OptionWidgetBase.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/OptionWidgetBase.h
@@ -107,7 +107,7 @@ protected:
     int SelectedIndex;
 
     /// Whether this option widget should set the up/down widgets to disabled at
-    /// the end of the range
+    /// the end of the range instead of hiding them as is the default.
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="OptionWidget")
     bool bDisableAtLimit = false;
 

--- a/Source/StevesUEHelpers/Public/StevesUI/OptionWidgetBase.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/OptionWidgetBase.h
@@ -50,6 +50,12 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (BindWidget), Category="OptionWidget")
     TObjectPtr<UImage> GamepadDownImage;    
 
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (BindWidgetOptional), Category="OptionWidget")
+    TObjectPtr<UImage> GamepadUpDisabledImage;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (BindWidgetOptional), Category="OptionWidget")
+    TObjectPtr<UImage> GamepadDownDisabledImage;
+
     UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (BindWidget), Category="OptionWidget")
     TObjectPtr<UTextBlock> GamepadText;
 
@@ -99,6 +105,11 @@ protected:
     TArray<FText> Options;
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category=Content)
     int SelectedIndex;
+
+    /// Whether this option widget should set the up/down widgets to disabled at
+    /// the end of the range
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="OptionWidget")
+    bool bDisableAtLimit = false;
 
     UFUNCTION(BlueprintCallable, Category="OptionWidget")
     virtual void SetMouseMode();

--- a/doc/OptionWidget.md
+++ b/doc/OptionWidget.md
@@ -23,6 +23,22 @@ Since this widget is designed to fit inside other widgets, it's a good idea to
 change the sizing mode in the top-right to Custom, and set it to something
 representative for this widget e.g. 300x60.
 
+## Control the behaviour of the widget
+
+The Option Widget has a `Disable at Limit` option which is off by default.
+When enabled, it changes the behaviour of the widget when the selection index
+reaches the start or end of the option list:
+
+* When this option is off, the up or down buttons and images will be hidden
+  when it is not possible to increment or decrement the selection index, and
+  shown when it is possible.
+* When this option is on, the up or down mouse buttons remain visible at all
+  times, but are disabled when it is not possible to increment or decrement
+  the selection index, and enabled when it is possible. The mouse up and down
+  images remain visible at all times. The gamepad up or down images are
+  hidden when at the limits of the selection index, and optional "disabled"
+  versions of them become visible instead.
+
 ## Linking the visual elements
 
 `OptionWidgetBase` works by assuming a certain visual elements are present, which 
@@ -40,6 +56,14 @@ GamepadVersion|The container for all elements which will be shown when a gamepad
 GamepadDownImage|The image displayed when decrementing the selection index in gamepad mode is allowed
 GamepadUpImage|The image displayed when incrementing the selection index in gamepad mode is allowed
 GamepadText|The text widget which displays the selected item in gamepad mode
+
+Two additional elements may be present. They are optional, and only used when
+`Disable at Limit` is turned on.
+
+Element Name|Usage
+:------------|:-----
+GamepadDownDisabledImage|The image displayed when decrementing the selection index in gamepad mode is not allowed, and `bDisableAtLimit` is enabled
+GamepadUpDisabledImage|The image displayed when incrementing the selection index in gamepad mode is not allowed, and `bDisableAtLimit` is enabled
 
 An example of how to create a conforming visual widget can be found in the
 [Example project](https://github.com/sinbad/StevesUEExamples), under the Blueprints/UI/Components


### PR DESCRIPTION
This commit adds a new bDisableAtLimit option to the OptionWidget which defaults to false to ensure it does not affect existing widgets. It also corrects an issue highlighted in #29 by setting the property specifiers for the gamepad disabled image variables to BindWidgetOptional rather than BindWidget.

When bDisableAtLimit is false, the behaviour of the OptionWidget is unchanged - when at either the start or end of the option list, the appropriate mouse widget or gamepad image is hidden.

When bDisableAtLimit is true, instead of hiding the mouse widget at the start or end of the list, it is set to disabled. This means the widgets remain visible but are not interactable when at the start or end of the list. This will also show 'Disabled' versions of the gamepad images when at the start or end of the list.